### PR TITLE
Add library support when detecting signature match

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -8,8 +8,9 @@ channels:
 dependencies:
   # Define conda-forge packages here -> https://anaconda.org/search
   # When available, prefer the conda-forge packages over pip as installations are more efficient.
-  - python=3.9.13               # https://pyreadiness.org/3.9/ 
+  - python=3.9.13               # https://pyreadiness.org/3.9/
   - pip=22.1.2                  # https://pip.pypa.io/en/stable/news/
   - pip:
       # Define pip packages here -> https://pypi.org/
-      - rpaframework==21.0.1    # https://rpaframework.org/releasenotes.html
+      # - rpaframework==21.0.1    # https://rpaframework.org/releasenotes.html
+      - https://robocorp:freeasinbeer@devpi.robocorp.cloud/ci/test/+f/7a6/694f89f4830a4/rpaframework-21.1.0-py3-none-any.whl#sha256=7a6694f89f4830a42a250c254a5174c53b1a1839ad914933a45b39f39441d63b

--- a/robot.yaml
+++ b/robot.yaml
@@ -5,6 +5,8 @@ tasks:
   # Task names here are used when executing the bots, so renaming these is recommended.
   Run all tasks:
     shell: python -m robot --report NONE --outputdir output --logtitle "Task log" tasks.robot
+  Match Signatures With Library:
+    robotTaskName: Match Signatures With Library
 
 condaConfigFile: conda.yaml
 
@@ -14,7 +16,7 @@ environmentConfigs:
   - environment_darwin_amd64_freeze.yaml
   - conda.yaml
 
-artifactsDir: output  
+artifactsDir: output
 
 PATH:
   - .


### PR DESCRIPTION
Adds a new task called `Match Signatures With Library` which works with the WIP library [pre-release](https://github.com/robocorp/rpaframework/pull/805). (**21.1.0**)